### PR TITLE
Parse body of incoming request to extract webhook

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,8 +70,10 @@ const obtainToken = webhook => gitlabToken
 
 const commentSummonsBot = comment => comment.match(new RegExp(`@${botName}(\\[bot\\])?\\s*check`)) !== null;
 
-const Handler = async webhook => 
+const Handler = async request => 
 {
+    let webhook = JSON.parse(request.body);
+
     if (!validAction(webhook)) {
         return `ignored action of type ${webhook.object_kind}`;
     }


### PR DESCRIPTION
Assume we're receiving an entire HTTP request in the handler, and extract the body to JSON.

PR because this requires @strangerich to change the test inputs he's using.
Sample input can be found in https://github.com/ScottLogic/gitlab-cla-bot/tree/lambda-ify/sample_webhook_requests
These should probably be sanitised/replaced with dummy data & incorporated into unit tests when we get to that, so not committing them to master.