### PR TITLE
Avoid "GitlabClaBotLoggingBucket already exists"

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -22,11 +22,8 @@ functions:
   handler:
     handler: src/index.Handler
     events:
+      - existingS3:
+        bucket: ${self:custom.loggingBucketName}
+        events:
+          - s3:*
       - http: POST handler
-
-resources:
-  Resources:
-    GitlabClaBotLoggingBucket:
-      Type: AWS::S3::Bucket
-      Properties:
-        BucketName: ${self:custom.loggingBucketName}


### PR DESCRIPTION
The `serverless deploy` command always fails (except the first time) with the error:

```
  An error occurred: GitlabClaBotLoggingBucket - finos-gitlab-cla-bot-logs already exists.
```

Using https://www.npmjs.com/package/serverless-plugin-existing-s3 to work around the issue