### PR TITLE
Rename serverless descriptor

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-service: gitlab-example
+service: gitlab-cla-bot
 
 custom:
   loggingBucketName: gitlab-cla-bot-logs


### PR DESCRIPTION
The name of the descriptor is used to create all AWS resources; the term `example` is misleading.

/CC @sehaswell @strangerich 